### PR TITLE
rgw/curl: async curl client

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -78,6 +78,7 @@ set(librgw_common_srcs
   rgw_es_query.cc
   rgw_formats.cc
   rgw_http_client.cc
+  curl/client.cc
   rgw_keystone.cc
   rgw_ldap.cc
   rgw_lc.cc

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -1,0 +1,480 @@
+#include "client.h"
+
+#include <string>
+#include <unordered_map>
+#include <variant>
+
+#include <boost/asio/append.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ip/udp.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include <boost/system/system_error.hpp>
+
+#include <curl/curl.h>
+
+#include "common/async/service.h"
+
+#if !CURL_AT_LEAST_VERSION(7, 17, 1)
+#error "requires libcurl >= 7.17.1 for CURLOPT_OPENSOCKETFUNCTION"
+#endif
+
+namespace rgw::curl {
+
+boost::system::error_category& easy_category()
+{
+  static struct category : boost::system::error_category {
+    const char* name() const noexcept override { return "curl easy"; }
+    std::string message(int code) const override {
+      return ::curl_easy_strerror(static_cast<CURLcode>(code));
+    }
+  } instance;
+  return instance;
+}
+
+boost::system::error_category& multi_category()
+{
+  static struct category : boost::system::error_category {
+    const char* name() const noexcept override { return "curl multi"; }
+    std::string message(int code) const override {
+      return ::curl_multi_strerror(static_cast<CURLMcode>(code));
+    }
+  } instance;
+  return instance;
+}
+
+
+void easy_deleter::operator()(CURL* p) { ::curl_easy_cleanup(p); }
+
+easy_ptr easy_init(error_code& ec)
+{
+  auto easy = easy_ptr{::curl_easy_init()};
+  if (!easy) {
+    ec.assign(CURLE_OUT_OF_MEMORY, easy_category());
+  }
+  return easy;
+}
+
+easy_ptr easy_init()
+{
+  error_code ec;
+  auto easy = easy_init(ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_easy_init");
+  }
+  return easy;
+}
+
+template <typename T>
+void easy_setopt(CURL* easy, CURLoption option, T&& value, error_code& ec)
+{
+  CURLcode code = ::curl_easy_setopt(easy, option, std::forward<T>(value));
+  if (code != CURLE_OK) {
+    ec.assign(code, easy_category());
+  }
+}
+
+template <typename T>
+void easy_setopt(CURL* easy, CURLoption option, T&& value)
+{
+  error_code ec;
+  easy_setopt(easy, option, std::forward<T>(value), ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_easy_setopt");
+  }
+}
+
+
+void multi_deleter::operator()(CURLM* p) { ::curl_multi_cleanup(p); }
+
+multi_ptr multi_init(error_code& ec)
+{
+  auto multi = multi_ptr{::curl_multi_init()};
+  if (!multi) {
+    ec.assign(CURLE_OUT_OF_MEMORY, multi_category());
+  }
+  return multi;
+}
+
+multi_ptr multi_init()
+{
+  error_code ec;
+  auto multi = multi_init(ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_multi_init");
+  }
+  return multi;
+}
+
+template <typename T>
+void multi_setopt(CURLM* multi, CURLMoption option, T&& value, error_code& ec)
+{
+  CURLMcode mcode = ::curl_multi_setopt(multi, option, std::forward<T>(value));
+  if (mcode != CURLM_OK) {
+    ec.assign(mcode, multi_category());
+  }
+}
+
+template <typename T>
+void multi_setopt(CURLM* multi, CURLMoption option, T&& value)
+{
+  error_code ec;
+  multi_setopt(multi, option, std::forward<T>(value), ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_multi_setopt");
+  }
+}
+
+
+void slist_deleter::operator()(curl_slist* p) { ::curl_slist_free_all(p); }
+
+void slist_append(slist_ptr& p, const char* str, error_code& ec)
+{
+  if (curl_slist* tmp = ::curl_slist_append(p.get(), str); tmp) {
+    (void) p.release(); // will be freed by curl_slist_free_all(tmp)
+    p.reset(tmp);
+  } else {
+    ec.assign(CURLE_OUT_OF_MEMORY, easy_category());
+  }
+}
+
+void slist_append(slist_ptr& p, const char* str)
+{
+  error_code ec;
+  slist_append(p, str, ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_slist_append");
+  }
+}
+
+
+// libcurl callback functions
+static curl_socket_t opensocket_callback(void* user, curlsocktype purpose,
+                                         curl_sockaddr* address);
+static int closesocket_callback(void* user, curl_socket_t fd);
+static int socket_callback(CURL* easy, curl_socket_t fd, int what,
+                           void* user, void* socket);
+static int timer_callback(CURLM* multi, long timeout_ms, void* user);
+
+
+namespace ip = boost::asio::ip;
+
+// This implementation uses the 'multi_socket' flavor of the libcurl multi API:
+// https://curl.se/libcurl/c/libcurl-multi.html
+//
+// By providing our own CURLMOPT_TIMERFUNCTION AND CURLMOPT_SOCKETFUNCTION, we
+// can do all necessary polling and waiting on the given asio executor. As we
+// get wakeups from asio, we call curl_multi_socket_action() to do its
+// non-blocking socket i/o from within that executor.
+//
+// This also overrides CURLOPT_OPENSOCKETFUNCTION on each request to manage the
+// pool of asio sockets.
+class Client::Impl :
+    public boost::intrusive_ref_counter<Impl, boost::thread_unsafe_counter>,
+    public ceph::async::service_list_base_hook
+{
+ public:
+  explicit Impl(executor_type ex)
+    : svc(boost::asio::use_service<ceph::async::service<Impl>>(
+          boost::asio::query(ex, boost::asio::execution::context))),
+      ex(ex),
+      timer(ex),
+      multi(multi_init())
+  {
+    multi_setopt(multi.get(), CURLMOPT_TIMERFUNCTION, timer_callback);
+    multi_setopt(multi.get(), CURLMOPT_TIMERDATA, this);
+    multi_setopt(multi.get(), CURLMOPT_SOCKETFUNCTION, socket_callback);
+    multi_setopt(multi.get(), CURLMOPT_SOCKETDATA, this);
+
+    // register for service_shutdown() notifications
+    svc.add(*this);
+  }
+  ~Impl()
+  {
+    svc.remove(*this);
+  }
+
+  executor_type get_executor() const noexcept { return ex; }
+
+  void async_perform_impl(handler_type handler, CURL* easy)
+  {
+    // configure the easy handle and add it to the multi handle
+    error_code ec;
+    add_handle(easy, ec);
+    if (ec) {
+      boost::asio::post(boost::asio::bind_executor(get_executor(),
+          boost::asio::append(std::move(handler), ec)));
+      return;
+    }
+
+    // arrange for per-op cancellation
+    auto slot = boost::asio::get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this, easy);
+    }
+
+    // register the completion handler
+    handlers.emplace(easy, std::move(handler));
+
+    // kick things off if they haven't started yet
+    socket_action(CURL_SOCKET_TIMEOUT, 0);
+  }
+
+  void cancel(error_code ec)
+  {
+    auto h = handlers.begin();
+    while (h != handlers.end()) {
+      auto handler = std::move(h->second);
+      ::curl_multi_remove_handle(multi.get(), h->first);
+      h = handlers.erase(h);
+      boost::asio::dispatch(boost::asio::append(std::move(handler), ec));
+    }
+    timer.cancel();
+  }
+
+  void service_shutdown()
+  {
+    auto h = handlers.begin();
+    while (h != handlers.end()) {
+      auto handler = std::move(h->second);
+      ::curl_multi_remove_handle(multi.get(), h->first);
+      h = handlers.erase(h);
+    }
+  }
+
+ private:
+  ceph::async::service<Impl>& svc;
+  executor_type ex;
+  boost::asio::steady_timer timer;
+  multi_ptr multi;
+
+  using client_socket = std::variant<ip::tcp::socket, ip::udp::socket>;
+  using client_socket_map = std::unordered_map<curl_socket_t, client_socket>;
+  client_socket_map sockets;
+
+  using handler_map = std::unordered_map<CURL*, handler_type>;
+  handler_map handlers;
+
+  // handler for per-op cancellation
+  struct op_cancellation {
+    Impl* impl;
+    CURL* easy;
+
+    op_cancellation(Impl* impl, CURL* easy)
+      : impl(impl), easy(easy) {}
+
+    void operator()(boost::asio::cancellation_type_t type) {
+      if (type == boost::asio::cancellation_type::none) {
+        return;
+      }
+      auto h = impl->handlers.find(easy);
+      if (h == impl->handlers.end()) {
+        return;
+      }
+      auto ec = make_error_code(boost::asio::error::operation_aborted);
+      auto handler = std::move(h->second);
+      ::curl_multi_remove_handle(impl->multi.get(), easy);
+      impl->handlers.erase(h);
+      boost::asio::dispatch(boost::asio::append(std::move(handler), ec));
+    }
+  };
+
+  void add_handle(CURL* easy, error_code& ec)
+  {
+    // attach socket callbacks to the easy handle
+    easy_setopt(easy, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback, ec);
+    if (ec) {
+      return;
+    }
+    easy_setopt(easy, CURLOPT_OPENSOCKETDATA, this, ec);
+    if (ec) {
+      return;
+    }
+    easy_setopt(easy, CURLOPT_CLOSESOCKETFUNCTION, closesocket_callback, ec);
+    if (ec) {
+      return;
+    }
+    easy_setopt(easy, CURLOPT_CLOSESOCKETDATA, this, ec);
+    if (ec) {
+      return;
+    }
+
+    // register the easy handle with the multi handle
+    CURLMcode mcode = ::curl_multi_add_handle(multi.get(), easy);
+    if (mcode != CURLM_OK) {
+      ec.assign(mcode, multi_category());
+      return;
+    }
+  }
+
+  void socket_action(curl_socket_t fd, int events)
+  {
+    // process the socket action as many times as necessary
+    CURLMcode mcode = CURLM_OK;
+    int count = 0;
+    do {
+      mcode = ::curl_multi_socket_action(multi.get(), fd, events, &count);
+    } while (mcode == CURLM_CALL_MULTI_PERFORM);
+
+    if (mcode != CURLM_OK) {
+      // on error, all transfers must be aborted
+      cancel(error_code{mcode, multi_category()});
+      return;
+    }
+
+    // handle any completions
+    while (CURLMsg* msg = ::curl_multi_info_read(multi.get(), &count)) {
+      if (msg->msg == CURLMSG_DONE) {
+        error_code ec;
+        if (msg->data.result != CURLE_OK) {
+          ec.assign(msg->data.result, easy_category());
+        }
+        auto h = handlers.find(msg->easy_handle);
+        if (h != handlers.end()) {
+          auto handler = std::move(h->second);
+          ::curl_multi_remove_handle(multi.get(), h->first);
+          handlers.erase(h);
+          boost::asio::dispatch(boost::asio::append(std::move(handler), ec));
+        }
+      }
+    }
+  }
+
+  // construct and open a tcp or udp socket
+  template <typename Protocol>
+  curl_socket_t open_socket(const Protocol& proto)
+  {
+    auto socket = typename Protocol::socket{get_executor()};
+    error_code ec;
+    socket.open(proto, ec);
+    if (ec) {
+      return CURL_SOCKET_BAD;
+    }
+    curl_socket_t fd = socket.native_handle();
+    sockets.emplace(std::piecewise_construct, std::forward_as_tuple(fd),
+                    std::forward_as_tuple(std::move(socket)));
+    return fd;
+  }
+
+  friend curl_socket_t opensocket_callback(void* user, curlsocktype purpose,
+                                           curl_sockaddr* address)
+  {
+    auto impl = static_cast<Impl*>(user);
+
+    if (address->socktype == SOCK_STREAM) {
+      auto proto = address->family == AF_INET ? ip::tcp::v4() : ip::tcp::v6();
+      return impl->open_socket(proto);
+    }
+    if (address->socktype == SOCK_DGRAM) {
+      auto proto = address->family == AF_INET ? ip::udp::v4() : ip::udp::v6();
+      return impl->open_socket(proto);
+    }
+    return CURL_SOCKET_BAD;
+  }
+
+  friend int closesocket_callback(void* user, curl_socket_t fd)
+  {
+    auto impl = static_cast<Impl*>(user);
+
+    impl->sockets.erase(fd);
+    return 0;
+  }
+
+  struct socket_wait_handler {
+    boost::intrusive_ptr<Impl> impl;
+    curl_socket_t fd;
+    int mask;
+
+    socket_wait_handler(boost::intrusive_ptr<Impl> impl,
+                        curl_socket_t fd, int mask)
+      : impl(std::move(impl)), fd(fd), mask(mask) {}
+
+    // callback for async_wait()
+    void operator()(error_code ec)
+    {
+      if (ec) {
+        mask |= CURL_CSELECT_ERR;
+      }
+      impl->socket_action(fd, mask);
+    }
+
+    // variant visitor for udp/tcp sockets
+    void operator()(auto& socket)
+    {
+      auto wait_flag = (mask == CURL_CSELECT_IN)
+          ? socket.wait_read : socket.wait_write;
+      socket.async_wait(wait_flag, std::move(*this));
+    }
+  };
+
+  friend int socket_callback(CURL* easy, curl_socket_t fd, int what,
+                             void* user, void* socket)
+  {
+    auto impl = static_cast<Impl*>(user);
+
+    if (what == CURL_POLL_REMOVE) {
+      return 0;
+    }
+
+    auto i = impl->sockets.find(fd);
+    if (i == impl->sockets.end()) {
+      return -1;
+    }
+
+    if (what & CURL_POLL_IN) {
+      std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_IN}, i->second);
+    }
+    if (what & CURL_POLL_OUT) {
+      std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_OUT}, i->second);
+    }
+    return 0;
+  }
+
+  friend int timer_callback(CURLM* multi, long timeout_ms, void* user)
+  {
+    boost::intrusive_ptr impl = static_cast<Impl*>(user);
+    if (timeout_ms == -1) {
+      impl->timer.cancel();
+      return 0;
+    }
+    impl->timer.expires_after(std::chrono::milliseconds(timeout_ms));
+    impl->timer.async_wait([impl] (error_code ec) {
+          if (!ec) {
+            impl->socket_action(CURL_SOCKET_TIMEOUT, 0);
+          }
+        });
+    return 0;
+  }
+};
+
+
+Client::Client(executor_type ex)
+  : impl(new Impl(ex))
+{
+}
+
+Client::~Client()
+{
+  cancel();
+}
+
+auto Client::get_executor() const noexcept -> executor_type
+{
+  return impl->get_executor();
+}
+
+void Client::async_perform_impl(handler_type handler, CURL* easy)
+{
+  impl->async_perform_impl(std::move(handler), easy);
+}
+
+void Client::cancel()
+{
+  impl->cancel(boost::asio::error::operation_aborted);
+}
+
+} // namespace rgw::curl

--- a/src/rgw/curl/client.h
+++ b/src/rgw/curl/client.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/system/error_category.hpp>
+#include <boost/system/error_code.hpp>
+
+struct curl_slist;
+
+namespace rgw::curl {
+
+using error_code = boost::system::error_code;
+
+/// Error category corresponding to CURLcode.
+boost::system::error_category& easy_category();
+
+/// Error category corresponding to CURLMcode.
+boost::system::error_category& multi_category();
+
+
+struct easy_deleter { void operator()(void* p); };
+/// A unique_ptr wrapper for CURL easy handles.
+using easy_ptr = std::unique_ptr<void, easy_deleter>;
+
+/// Create an easy handle with curl_easy_init(). May fail with
+/// CURLE_OUT_OF_MEMORY.
+easy_ptr easy_init(error_code& ec);
+/// \overload
+easy_ptr easy_init(); // throws on error
+
+
+struct multi_deleter { void operator()(void* p); };
+/// A unique_ptr wrapper for CURLM multi handles.
+using multi_ptr = std::unique_ptr<void, multi_deleter>;
+
+/// Create a multi handle with curl_multi_init(). May fail with
+/// CURLE_OUT_OF_MEMORY.
+multi_ptr multi_init(error_code& ec);
+/// \overload
+multi_ptr multi_init(); // throws on error
+
+
+struct slist_deleter { void operator()(curl_slist* p); };
+/// A unique_ptr wrapper for curl string lists.
+using slist_ptr = std::unique_ptr<curl_slist, slist_deleter>;
+
+/// Allocate a new slist entry to hold a copy of the given string and update
+/// the slist_ptr to point at the new head. May fail with CURLE_OUT_OF_MEMORY.
+void slist_append(slist_ptr& p, const char* str, error_code& ec);
+/// \overload
+void slist_append(slist_ptr& p, const char* str); // throws on error
+
+
+/// \brief Asynchronous libcurl HTTP client.
+///
+/// An asynchronous multiplexing libcurl client that runs exclusively on the
+/// given asio io executor. Each instance of Client manages its own curl multi
+/// handle and connection pool.
+///
+/// This class is not thread-safe, so a strand executor should be used in
+/// multi-threaded contexts, and all member functions must be called within
+/// that strand.
+class Client {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+
+  /// Create and configure a curl multi handle.
+  explicit Client(executor_type ex);
+
+  /// Cancel any pending requests and close the curl handles.
+  ~Client();
+
+  /// Return the io executor.
+  executor_type get_executor() const noexcept;
+
+  /// \brief Perform an asynchronous http request with libcurl.
+  ///
+  /// Send the http request asynchronously, as if by curl_easy_perform(), and
+  /// invoke the handler on completion. The caller must keep the easy handle
+  /// alive in the meantime.
+  ///
+  /// The operation can be canceled by binding a cancellation slot to the
+  /// given CompletionToken.
+  template <boost::asio::completion_token_for<void(error_code)> CompletionToken>
+  auto async_perform(void* easy, CompletionToken&& token)
+  {
+    return boost::asio::async_initiate<CompletionToken, void(error_code)>(
+        [this, easy] (handler_type handler) {
+          async_perform_impl(std::move(handler), easy);
+        }, token);
+  }
+
+  /// Cancel all pending requests with boost::asio::error::operation_aborted.
+  void cancel();
+
+ private:
+  class Impl;
+  boost::intrusive_ptr<Impl> impl;
+
+  using handler_type = boost::asio::any_completion_handler<void(error_code)>;
+  void async_perform_impl(handler_type handler, void* easy);
+};
+
+} // namespace rgw::curl

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -42,6 +42,11 @@ add_executable(unittest_rgw_compression
 add_ceph_unittest(unittest_rgw_compression)
 target_link_libraries(unittest_rgw_compression ${rgw_libs})
 
+# unitttest_rgw_curl_client
+add_executable(unittest_rgw_curl_client test_rgw_curl_client.cc)
+add_ceph_unittest(unittest_rgw_curl_client)
+target_link_libraries(unittest_rgw_curl_client ${rgw_libs})
+
 # unitttest_http_manager
 add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)

--- a/src/test/rgw/test_rgw_curl_client.cc
+++ b/src/test/rgw/test_rgw_curl_client.cc
@@ -1,0 +1,458 @@
+#include "curl/client.h"
+#include <gtest/gtest.h>
+#include <chrono>
+#include <exception>
+#include <optional>
+#include <string>
+#include <boost/asio.hpp>
+#include <curl/curl.h>
+#include <fmt/format.h>
+
+namespace rgw::curl {
+
+namespace asio = boost::asio;
+namespace ip = asio::ip;
+
+using namespace std::chrono_literals;
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) { opt = std::move(value); };
+}
+
+template <typename T>
+auto capture(asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+void rethrow(std::exception_ptr eptr)
+{
+  if (eptr) std::rethrow_exception(eptr);
+}
+
+auto accept_connection(ip::tcp::acceptor& acceptor, size_t keepalive_count)
+    -> asio::awaitable<void>
+{
+  auto socket = co_await acceptor.async_accept(asio::use_awaitable);
+
+  for (size_t i = 0; i < keepalive_count; i++) {
+    std::string request;
+    co_await asio::async_read_until(socket, asio::dynamic_buffer(request),
+                                    "\r\n\r\n", asio::use_awaitable);
+
+    static constexpr std::string_view response =
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+    co_await asio::async_write(socket, asio::buffer(response),
+                               asio::use_awaitable);
+  }
+}
+
+auto perform(Client& client, const char* url)
+    -> asio::awaitable<void>
+{
+  auto easy = easy_init();
+  ::curl_easy_setopt(easy.get(), CURLOPT_URL, url);
+
+  co_await client.async_perform(easy.get(), asio::use_awaitable);
+}
+
+TEST(Client, one)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(1);
+
+  std::optional<std::exception_ptr> septr;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr));
+
+  sctx.poll(); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr));
+
+  cctx.poll(); // client spawn + write, block on wait_read
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr);
+
+  sctx.poll(); // server accept + read + write
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr);
+  EXPECT_FALSE(*septr);
+
+  cctx.poll(); // client wait_read completes, timer is canceled
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr);
+  EXPECT_FALSE(*ceptr);
+}
+
+TEST(Client, cancel_destroy)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(1);
+
+  std::optional<std::exception_ptr> septr;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr));
+
+  sctx.poll();
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto cr = [&cctx] (const char* url) -> asio::awaitable<void> {
+    auto client = Client{cctx.get_executor()};
+    co_await perform(client, url);
+  };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> ceptr;
+  asio::co_spawn(cctx, cr(url.c_str()), capture(signal, ceptr));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr);
+
+  // cancel before the server runs
+  signal.emit(asio::cancellation_type::terminal);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr);
+  EXPECT_FALSE(*septr);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr);
+  ASSERT_TRUE(*ceptr);
+  try {
+    std::rethrow_exception(*ceptr);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Client, two)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(2);
+
+  // accept a single request then close the connection
+  std::optional<std::exception_ptr> septr1;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr1));
+
+  EXPECT_EQ(1, sctx.poll()); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr1);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr1));
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+  EXPECT_FALSE(ceptr2);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr1);
+  EXPECT_FALSE(*septr1);
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  EXPECT_FALSE(*ceptr1);
+
+  // accept a second connection
+  std::optional<std::exception_ptr> septr2;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr2));
+
+  sctx.restart();
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr2);
+  EXPECT_FALSE(*septr2);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr2);
+  EXPECT_FALSE(*ceptr2);
+}
+
+TEST(Client, two_keepalive)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(1);
+
+  // accept two requests on the same connection
+  std::optional<std::exception_ptr> septr;
+  asio::co_spawn(sctx, accept_connection(acceptor, 2), capture(septr));
+
+  EXPECT_EQ(1, sctx.poll()); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr1));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+
+  sctx.poll();
+  ASSERT_FALSE(sctx.stopped());
+  ASSERT_FALSE(septr);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  EXPECT_FALSE(*ceptr1);
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.restart();
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr2);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr);
+  EXPECT_FALSE(*septr);
+
+  cctx.run_for(10ms);
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr2);
+  EXPECT_FALSE(*ceptr2);
+}
+
+TEST(Client, two_signal_one)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(2);
+
+  std::optional<std::exception_ptr> septr1;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr1));
+  std::optional<std::exception_ptr> septr2;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr2));
+
+  sctx.poll(); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr1);
+  EXPECT_FALSE(septr2);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(signal, ceptr1));
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+  EXPECT_FALSE(ceptr2);
+
+  // cancel before server runs
+  signal.emit(asio::cancellation_type::terminal);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr1);
+  EXPECT_FALSE(*septr1);
+  ASSERT_TRUE(septr2);
+  EXPECT_FALSE(*septr2);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  ASSERT_TRUE(*ceptr1);
+  try {
+    std::rethrow_exception(*ceptr1);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+  ASSERT_TRUE(ceptr2);
+  EXPECT_FALSE(*ceptr2);
+}
+
+TEST(Client, two_cancel)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(2);
+
+  std::optional<std::exception_ptr> septr1;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr1));
+  std::optional<std::exception_ptr> septr2;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr2));
+
+  sctx.poll(); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr1);
+  EXPECT_FALSE(septr2);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr1));
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+  EXPECT_FALSE(ceptr2);
+
+  // cancel before server runs
+  client.cancel();
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr1);
+  EXPECT_FALSE(*septr1);
+  ASSERT_TRUE(septr2);
+  EXPECT_FALSE(*septr2);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  ASSERT_TRUE(*ceptr1);
+  try {
+    std::rethrow_exception(*ceptr1);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+  ASSERT_TRUE(ceptr2);
+  ASSERT_TRUE(*ceptr2);
+  try {
+    std::rethrow_exception(*ceptr2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+auto client_load(Client& client, const char* url, size_t count)
+    -> asio::awaitable<void>
+{
+  for (size_t i = 0; i < count; i++) {
+    co_await perform(client, url);
+  }
+}
+
+TEST(ClientLoad, single_thread)
+{
+  constexpr size_t max_connections = 8;
+  constexpr size_t requests_per_connection = 256;
+
+  asio::io_context ctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{ctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(max_connections);
+
+  auto client = Client{ctx.get_executor()};
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  for (size_t i = 0; i < max_connections; i++) {
+    asio::co_spawn(ctx, accept_connection(acceptor,
+        requests_per_connection), rethrow);
+    asio::co_spawn(ctx, client_load(client, url.c_str(),
+        requests_per_connection), rethrow);
+  }
+
+  ctx.run();
+}
+
+TEST(ClientLoad, multi_thread)
+{
+  constexpr size_t num_threads = 8;
+  constexpr size_t max_connections = 8;
+  constexpr size_t requests_per_connection = 256;
+
+  auto ctx = asio::static_thread_pool{num_threads};
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{ctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(max_connections);
+
+  for (size_t i = 0; i < max_connections; i++) {
+    asio::co_spawn(ctx, accept_connection(acceptor,
+        requests_per_connection), rethrow);
+  }
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  auto ex = asio::make_strand(ctx);
+  auto client = Client{ex};
+  for (size_t i = 0; i < max_connections; i++) {
+    asio::co_spawn(ex, client_load(client, url.c_str(),
+        requests_per_connection), rethrow);
+  }
+
+  ctx.join();
+}
+
+} // namespace rgw::curl


### PR DESCRIPTION
# note that this PR is based on top of https://github.com/ceph/ceph/pull/50064 which targets Ceph's wip-coro-after-reef feature branch
in contrast to `RGWHTTPManager`'s background thread that polls on `curl_multi_wait()`/`curl_multi_perform()`, this uses a different flavor of the curl_multi API that integrates much better with boost::asio:
```
// This implementation uses the 'multi_socket' flavor of the libcurl multi API:
// https://curl.se/libcurl/c/libcurl-multi.html
//
// By providing our own CURLMOPT_TIMERFUNCTION AND CURLMOPT_SOCKETFUNCTION, we
// can do all necessary polling and waiting on the given asio executor. As we
// get wakeups from asio, we call curl_multi_socket_action() to do its
// non-blocking socket i/o from within that executor.
//
// This also overrides CURLOPT_OPENSOCKETFUNCTION on each request to manage the
// pool of asio sockets.
```